### PR TITLE
Show expire / redeem buttons only when available

### DIFF
--- a/components/ExpireContract.vue
+++ b/components/ExpireContract.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="dialog" persistent max-width="600px">
+  <v-dialog v-model="dialog" v-if="pastExpiry" persistent max-width="600px">
     <template #activator="{ on, attrs }">
       <v-btn color="primary" text v-bind="attrs" v-on="on"> Expire</v-btn>
     </template>
@@ -38,6 +38,7 @@ import { Component, namespace, Prop, Vue } from "nuxt-property-decorator"
 import { LSPConfiguration } from "~/types"
 
 const contracts = namespace("contracts")
+const web3 = namespace("web3")
 
 @Component
 export default class expireContract extends Vue {
@@ -49,6 +50,15 @@ export default class expireContract extends Vue {
 
   @contracts.Action
   expireContract!: (syntheticName: string) => Promise<void>
+
+  @web3.Getter
+  getBlockTimestamp!: number
+
+
+  get pastExpiry(){
+      const expirationTimestamp = new Date(this.contractDetails.expirationTime).getTime() / 1000
+      return expirationTimestamp < this.getBlockTimestamp
+  }
 
   async expire() {
     try {

--- a/components/RedeemTokens.vue
+++ b/components/RedeemTokens.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="dialog" persistent max-width="600px">
+    <v-dialog v-model="dialog" persistent max-width="600px" v-if="tokenPairs>0">
     <template #activator="{ on, attrs }">
       <v-btn color="primary" text v-bind="attrs" v-on="on"> Redeem</v-btn>
     </template>

--- a/store/web3.ts
+++ b/store/web3.ts
@@ -47,7 +47,11 @@ export default class web3 extends VuexModule {
   selectedAccountAddress = ""
   networkInfo: ethers.providers.Network = { name: "", chainId: -1 }
   correctNetwork = "kovan"
+  blockTimestamp = 0
 
+  get getBlockTimestamp(): number {
+    return this.blockTimestamp
+  }
   get selectedAccount(): string {
     return this.selectedAccountAddress
   }
@@ -55,7 +59,6 @@ export default class web3 extends VuexModule {
   get getConnectionStatus(): boolean {
     return this.isConnected
   }
-
 
   get onCorrectNetwork() {
     return this.networkInfo.name === this.correctNetwork
@@ -97,6 +100,11 @@ export default class web3 extends VuexModule {
   @Mutation
   setConnectionStatus(status: boolean) {
     this.isConnected = status
+  }
+
+  @Mutation
+  setBlockTimestamp(timestamp: number) {
+    this.blockTimestamp = timestamp
   }
 
   @Mutation
@@ -176,6 +184,17 @@ export default class web3 extends VuexModule {
       window.ethereum.on("chainChanged", () => {
         console.log("Detected network change, reload page")
         window.location.reload()
+      })
+    }
+    let self = this
+    const provider = getCurrentProvider()
+    if (provider !== undefined) {
+      console.log("Registering new block listener")
+      provider.on("block", async function (blockNumber) {
+        console.log("New Block: " + blockNumber)
+        const block = await provider.getBlock(blockNumber)
+        console.log("Block timestamp: ", block.timestamp)
+        self.context.commit("setBlockTimestamp", block.timestamp)
       })
     }
   }


### PR DESCRIPTION
1. Show expire button only after the time of expiry has passed according to the latest block timestamp
2. Show redeem button only if the user has long / short pairs that he can redeem